### PR TITLE
parso 0.8.5: add py314 support

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,8 @@ test:
 about:
   home: https://github.com/davidhalter/parso
   license: MIT
-license: MIT AND PSF
-license_family: OTHER
+  license: MIT AND PSF
+  license_family: OTHER
   license_file: LICENSE.txt
   summary: A Python Parser
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "parso" %}
-{% set version = "0.8.4" %}
+{% set version = "0.8.5" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d
+  sha256: 034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a
 
 build:
   number: 0
+  skip: true # [py<36]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ test:
 about:
   home: https://github.com/davidhalter/parso
   license: MIT
-  license_family: MIT
+license: MIT AND PSF
+license_family: OTHER
   license_file: LICENSE.txt
   summary: A Python Parser
   description: |


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-10717) 
- [Upstream repository](https://github.com/davidhalter/parso/tree/v0.8.5)

### Explanation of changes:

- Skip py<36
- Add py314 support in abs.yaml

### Notes:

- Python 3.14 support was added in v0.8.5, see https://github.com/davidhalter/parso/blob/v0.8.5/CHANGELOG.rst#085-2025-08-23