### PR TITLE
parso 0.8.7 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "parso" %}
-{% set version = "0.8.5" %}
+{% set version = "0.8.7" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1
 
 build:
   number: 0
@@ -16,8 +16,8 @@ build:
 
 requirements:
   host:
-    - python
     - pip
+    - python
     - setuptools
     - wheel
   run:


### PR DESCRIPTION
parso 0.8.7 

**Destination channel:** Defaults

### Links

- [PKG-14770]
- dev_url:        https://github.com/davidhalter/parso/tree/v0.8.7
- conda_forge:    https://github.com/conda-forge/parso-feedstock
- pypi:           https://pypi.org/project/parso/0.8.7
- pypi inspector: https://inspector.pypi.io/project/parso/0.8.7

### Explanation of changes:

- new version number


[PKG-14770]: https://anaconda.atlassian.net/browse/PKG-14770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ